### PR TITLE
[WIP] Updated for Spree 3.2.0.rc2 and Rails 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree'
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise'
-gem 'spree_events_tracker', git: 'https://github.com/vinsol/spree_events_tracker'
+gem 'spree', github: 'spree/spree', branch: '3-2-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: 'master'
+gem 'spree_events_tracker', github: 'vinsol-spree-contrib/spree_events_tracker', branch: 'master'
 
 group :test do
   gem 'rails-controller-testing'

--- a/app/models/concerns/spree/marketing/calculate_reports.rb
+++ b/app/models/concerns/spree/marketing/calculate_reports.rb
@@ -6,7 +6,7 @@ module Spree
 
       def log_ins_by
         actor_ids = Spree::PageEvent.of_registered_users
-                                    .where(actor_id: user_ids, actor_type: Spree.user_class)
+                                    .where(actor_id: user_ids, actor_type: Spree.user_class.name)
                                     .where("created_at >= :scheduled_time", scheduled_time: scheduled_at)
                                     .distinct
                                     .pluck(:actor_id)
@@ -36,7 +36,7 @@ module Spree
 
       def product_views_by
         actor_ids = Spree::PageEvent.of_registered_users
-                                    .where(actor_id: user_ids, actor_type: Spree.user_class, target_type: "Spree::Product", activity: "view")
+                                    .where(actor_id: user_ids, actor_type: Spree.user_class.name, target_type: "Spree::Product", activity: "view")
                                     .where("created_at >= :scheduled_time", scheduled_time: scheduled_at)
                                     .distinct
                                     .pluck(:actor_id)

--- a/app/models/spree/marketing/list/least_active_users.rb
+++ b/app/models/spree/marketing/list/least_active_users.rb
@@ -13,7 +13,7 @@ module Spree
                           .having('COUNT(spree_page_events.id) < :maximum_count', maximum_count: MAXIMUM_PAGE_EVENT_COUNT)
                           .of_registered_users
                           .where('created_at >= :time_frame', time_frame: computed_time)
-                          .where(actor_type: Spree.user_class)
+                          .where(actor_type: Spree.user_class.name)
                           .pluck(:actor_id)
         end
       end

--- a/app/models/spree/marketing/list/most_active_users.rb
+++ b/app/models/spree/marketing/list/most_active_users.rb
@@ -13,7 +13,7 @@ module Spree
                           .having('COUNT(spree_page_events.id) > ?', MINIMUM_PAGE_EVENT_COUNT)
                           .where('created_at >= :time_frame', time_frame: computed_time)
                           .of_registered_users
-                          .where(actor_type: Spree.user_class)
+                          .where(actor_type: Spree.user_class.name)
                           .pluck(:actor_id)
         end
 

--- a/app/models/spree/marketing/list/most_searched_keywords.rb
+++ b/app/models/spree/marketing/list/most_searched_keywords.rb
@@ -17,7 +17,7 @@ module Spree
           Spree::PageEvent.where(search_keywords: searched_keyword)
                           .where('created_at >= :time_frame', time_frame: computed_time)
                           .of_registered_users
-                          .where(actor_type: Spree.user_class)
+                          .where(actor_type: Spree.user_class.name)
                           .group(:actor_id)
                           .pluck(:actor_id)
         end

--- a/spec/lib/mailchimp_error_handler_spec.rb
+++ b/spec/lib/mailchimp_error_handler_spec.rb
@@ -5,7 +5,9 @@ describe MailchimpErrorHandler, type: :module do
 
   let(:retry_attempt) { 2 }
 
-  SpreeMarketing::CONFIG = { Rails.env => { campaign_defaults: { from_email: 'a@test.com' }} }
+  before do
+    stub_const("SpreeMarketing::CONFIG", { Rails.env => { campaign_defaults: { from_email: 'a@test.com' }} })
+  end
 
   class TestJob < ActiveJob::Base
     include MailchimpErrorHandler

--- a/spec/mailers/spree/marketing/mailchimp_error_notifier_spec.rb
+++ b/spec/mailers/spree/marketing/mailchimp_error_notifier_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 
 RSpec.describe Spree::Marketing::MailchimpErrorNotifier do
 
-  SpreeMarketing::CONFIG = { Rails.env => { campaign_defaults: { from_email: 'a@test.com' }} }
+
+  before do
+    stub_const("SpreeMarketing::CONFIG", { Rails.env => { campaign_defaults: { from_email: 'a@test.com' }} })
+  end
 
   describe 'notify_failure' do
 

--- a/spree_marketing.gemspec
+++ b/spree_marketing.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_marketing'
-  s.version     = '3.2.0.alpha'
+  s.version     = '3.2.0.rc2'
   s.summary     = 'Add gem summary here'
   s.description = 'Add (optional) gem description here'
   s.required_ruby_version = '>= 2.0.0'
@@ -16,7 +16,8 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.2.0.alpha'
+  s.add_dependency 'spree_core', '~> 3.2.0.rc2'
+  s.add_dependency 'spree_events_tracker', '~> 3.2.0.rc2'
   s.add_dependency 'gibbon',     '~> 2.2.3'
   s.add_dependency 'whenever',   '~> 0.9.4'
 


### PR DESCRIPTION
Fixed Deprecation Warning :: Passing a class as a value in an Active Record query is deprecated and will be removed. Pass a string instead.
Refer https://github.com/rails/rails/pull/17916
Used Rspec stub_const to silence CONSTANT redefinition warnings
Pending: Failing Specs for acts_as_multilist concern
TRACE_START
Spree::Marketing::List::MostZoneWiseOrders behaves like acts_as_multilist .generator if list doesn't exists should change result by 1
      Failure/Error: it { expect { list_type.send :generator }.to change { list_type.all.count }.by 1 }
        expected result to have changed by 1, but was changed by 0
      Shared Example Group: "acts_as_multilist" called from ./spec/models/spree/marketing/list/most_zone_wise_orders_list_spec.rb:12
      # ./spec/shared/acts_as_multilist.rb:59:in `block (4 levels) in <top (required)>'
TRACE_END